### PR TITLE
Get rid of unnecessary progress bar in Debugger

### DIFF
--- a/src/components/tools/Debugger.js
+++ b/src/components/tools/Debugger.js
@@ -373,9 +373,6 @@ class Debugger extends Tool {
 						</Box>
 					</CustomSplit>
 				</Box>
-				<Box>
-					{stepping && <LinearProgress variant="indeterminate" />}
-				</Box>
 			</Box>
 		);
 	}


### PR DESCRIPTION
This bar in made editor "jump" in every action (step over, step into, etc.).
Also, a new backend test for temp variables in debugger scope.