### PR TITLE
Class definition from editor/Code search fixes

### DIFF
--- a/src/components/Backend.js
+++ b/src/components/Backend.js
@@ -652,8 +652,8 @@ class Backend {
 	async defineClass(classname, superclassname, packagename, definition) {
 		const description = "define class " + classname;
 		const change = this.newChange("AddClass");
-		change.className = classname;
-		change.superclass = superclassname;
+		if (classname) change.className = classname;
+		if (superclassname) change.superclass = superclassname;
 		change.package = packagename;
 		change.definition = definition;
 		const changes = await this.usesChanges();

--- a/src/components/parts/CodeBrowser.js
+++ b/src/components/parts/CodeBrowser.js
@@ -50,13 +50,11 @@ class CodeBrowser extends Component {
 		if (!this.props.class) return;
 		const pack = this.props.package;
 		const species = this.props.class;
-		const classname = species ? species.name : null;
-		const superclass = species ? species.superclass : null;
 		const packagename = pack ? pack.name : species ? species.package : null;
 		try {
 			const change = await ide.backend.defineClass(
-				classname,
-				superclass,
+				null,
+				null,
 				packagename,
 				definition
 			);

--- a/src/components/parts/CodeEditor.js
+++ b/src/components/parts/CodeEditor.js
@@ -268,7 +268,8 @@ class CodeEditor extends Component {
 		const json = this.props.ast;
 		if (!json) return;
 		const ast = new StAST();
-		return ast.fromJson(json);
+		ast.fromJson(json);
+		return ast;
 	}
 
 	astRangesSatisfying(condition) {

--- a/src/components/parts/MethodList.js
+++ b/src/components/parts/MethodList.js
@@ -406,6 +406,7 @@ class MethodList extends Component {
 	};
 
 	browseLocalImplementors = (selector, classname) => {
+		console.log(selector, classname);
 		if (selector && classname)
 			this.context.browseLocalImplementors(selector, classname);
 	};
@@ -710,7 +711,12 @@ class MethodList extends Component {
 				<OverridingOverridenIcon
 					color="primary"
 					style={{ fontSize: size }}
-					onClick={(event) => this.browseLocalImplementors(method)}
+					onClick={(event) =>
+						this.browseLocalImplementors(
+							method.selector,
+							method.methodClass
+						)
+					}
 				/>
 			);
 		}
@@ -719,7 +725,12 @@ class MethodList extends Component {
 				<OverridingIcon
 					color="primary"
 					style={{ fontSize: size }}
-					onClick={(event) => this.browseLocalImplementors(method)}
+					onClick={(event) =>
+						this.browseLocalImplementors(
+							method.selector,
+							method.methodClass
+						)
+					}
 				/>
 			);
 		}
@@ -728,7 +739,12 @@ class MethodList extends Component {
 				<OverridenIcon
 					color="primary"
 					style={{ fontSize: size }}
-					onClick={(event) => this.browseLocalImplementors(method)}
+					onClick={(event) =>
+						this.browseLocalImplementors(
+							method.selector,
+							method.methodClass
+						)
+					}
 				/>
 			);
 		}
@@ -786,13 +802,13 @@ class MethodList extends Component {
 			//icon: <ImplementorsIcon style={{ fontSize: 14 }} />,
 			icon: <Typography color="primary">i</Typography>,
 			label: "Implementors",
-			handler: this.browseImplementors,
+			handler: (m) => this.browseImplementors(m.selector),
 		});
 		actions.push({
 			//icon: <SendersIcon style={{ fontSize: 14 }} />,
 			icon: <Typography color="primary">s</Typography>,
 			label: "Senders",
-			handler: this.browseSenders,
+			handler: (m) => this.browseSenders(m.selector),
 		});
 		return actions;
 	};


### PR DESCRIPTION
- Avoid passing the selected class when accepting the definition of a class from the CodeEditor.
- Also, fixe senders/implementors searchs access from 's'/'i' buttons over selectors in MethodList.
- Finally, fix tool tips in CodeEditor that depend on AST traversing for senders/implementors searches.