### PR TITLE
Prevent default behavior of shortcuts. For some reason

### DIFF
--- a/src/components/IDE.js
+++ b/src/components/IDE.js
@@ -417,7 +417,12 @@ class IDE extends Component {
 
 	async updateSettings() {
 		this.initializeBackend();
-		const dialect = await this.backend.dialect();
+		let dialect;
+		try {
+			dialect = await this.backend.dialect();
+		} catch (error) {
+			this.reportError(error);
+		}
 		try {
 			this.logo = await this.backend.logo();
 		} catch (error) {}

--- a/src/components/parts/CodeEditor.js
+++ b/src/components/parts/CodeEditor.js
@@ -208,7 +208,12 @@ class CodeEditor extends Component {
 	}
 
 	async initializeExtendedOptions() {
-		const extensions = await ide.backend.extensions("code");
+		let extensions;
+		try {
+			extensions = await ide.backend.extensions("code");
+		} catch (ignored) {
+			extensions = [];
+		}
 		this.setState({ extendedOptions: extensions });
 	}
 
@@ -485,8 +490,7 @@ class CodeEditor extends Component {
 		);
 	};
 
-	acceptClicked = (editor, event) => {
-		if (event) event.preventDefault();
+	acceptClicked = () => {
 		if (this.props.onAccept) this.props.onAccept(this.state.source);
 	};
 
@@ -572,8 +576,7 @@ class CodeEditor extends Component {
 		this.context.browseLocalImplementors(selector, this.props.class.name);
 	};
 
-	browseClass = (e, f) => {
-		f.stopPropagation();
+	browseClass = () => {
 		const target = this.targetWord();
 		target
 			? this.context.browseClass(target)
@@ -829,10 +832,12 @@ class CodeEditor extends Component {
 			{
 				key: this.adaptShortcut(shortcuts.get("acceptCode")),
 				run: this.acceptClicked,
+				preventDefault: true,
 			},
 			{
 				key: this.adaptShortcut(shortcuts.get("browseClass")),
 				run: this.browseClass,
+				preventDefault: true,
 			},
 			{
 				key: this.adaptShortcut(shortcuts.get("browseSenders")),

--- a/src/components/parts/MethodList.js
+++ b/src/components/parts/MethodList.js
@@ -166,7 +166,7 @@ class MethodList extends Component {
 				} catch (error) {
 					ide.reportError(error);
 				}
-				grouped[c.name] = fetched;
+				grouped[c.name] = fetched || [];
 			})
 		);
 		let selectors = {};
@@ -816,7 +816,16 @@ class MethodList extends Component {
 
 	newMethod = async () => {
 		const selected = this.state.selectedMethod;
-		const template = await ide.backend.methodTemplate();
+		let template;
+		try {
+			template = await ide.backend.methodTemplate();
+		} catch (ignored) {
+			template = {
+				selector: "newMethod",
+				source: "newMethod",
+				template: true,
+			};
+		}
 		template.methodClass = selected
 			? selected.methodClass
 			: this.props.class

--- a/src/components/parts/PromptEditor.js
+++ b/src/components/parts/PromptEditor.js
@@ -185,18 +185,22 @@ class PromptEditor extends Component {
 			{
 				key: "Tab",
 				run: acceptCompletion,
+				preventDefault: true,
 			},
 			{
 				key: "Enter",
 				run: this.enterPressed,
+				preventDefault: true,
 			},
 			{
 				key: "Shift-Enter",
 				run: this.combinedEnterPressed,
+				preventDefault: true,
 			},
 			{
 				key: "Ctrl-Enter",
 				run: this.combinedEnterPressed,
+				preventDefault: true,
 			},
 		];
 	}


### PR DESCRIPTION
Prevent default behavior of shortcuts. For some reason (maybe a version update of CodeMirror), event handlers stop receiving the event, and could not prevent default behavior anymore.

Now it is avoided by specifying that en keymap definitions.