### PR TITLE
Handle an potential undefined result of dialogs

### DIFF
--- a/src/components/parts/CategoryList.js
+++ b/src/components/parts/CategoryList.js
@@ -70,7 +70,11 @@ class CategoryList extends Component {
 	}
 
 	async fetchExtendedOptions() {
-		return await ide.backend.extensions("category");
+		let extensions = [];
+		try {
+			extensions = await ide.backend.extensions("category");
+		} catch (ignored) {}
+		return extensions;
 	}
 
 	async updateExtendedOptions() {
@@ -92,9 +96,7 @@ class CategoryList extends Component {
 			const category = await ide.prompt({
 				title: "New category",
 			});
-			if (category) {
-				this.addCategory(category);
-			}
+			if (category) this.addCategory(category);
 		} catch (error) {}
 	};
 
@@ -113,6 +115,7 @@ class CategoryList extends Component {
 				title: "Rename category",
 				defaultValue: category,
 			});
+			if (!name) return;
 			await ide.backend.renameCategory(
 				this.props.class.name,
 				category,

--- a/src/components/parts/ChangesTable.js
+++ b/src/components/parts/ChangesTable.js
@@ -88,6 +88,7 @@ class ChangesTable extends Component {
 		const target = await ide.prompt({
 			title: "Enter " + property,
 		});
+		if (!target) return;
 		this.addFilter(property + " = " + target, (ch) => {
 			const source = property === "type" ? ch.type() : ch[property];
 			return source === target;
@@ -106,6 +107,7 @@ class ChangesTable extends Component {
 		const target = await ide.prompt({
 			title: "Enter " + property,
 		});
+		if (!target) return;
 		this.addFilter(property + " != " + target, (ch) => {
 			const source = property === "type" ? ch.type() : ch[property];
 			return source !== target;

--- a/src/components/parts/ClassTree.js
+++ b/src/components/parts/ClassTree.js
@@ -47,7 +47,11 @@ class ClassTree extends Component {
 		} catch (error) {
 			//In case there is no /search endpoint, we keep the list of class names
 			//in the system (at the moment of initialization).
-			this.classSearch = await ide.backend.classNames();
+			try {
+				this.classSearch = await ide.backend.classNames();
+			} catch (ignored) {
+				this.classSearch = [];
+			}
 		}
 	}
 
@@ -204,7 +208,11 @@ class ClassTree extends Component {
 	}
 
 	async fetchExtendedOptions() {
-		return await ide.backend.extensions("class");
+		let extensions = [];
+		try {
+			extensions = await ide.backend.extensions("class");
+		} catch (ignored) {}
+		return extensions;
 	}
 
 	findSubclass(name, root) {
@@ -299,6 +307,7 @@ class ClassTree extends Component {
 				title: "New " + superclass.name + " subclass",
 				required: true,
 			});
+			if (!name) return;
 			const packagename = this.props.package
 				? this.props.package.name
 				: superclass.package;
@@ -330,6 +339,7 @@ class ClassTree extends Component {
 				defaultValue: species.name,
 				required: true,
 			});
+			if (!newName) return;
 			await ide.waitFor(() =>
 				ide.backend.renameClass(species.name, newName)
 			);
@@ -439,20 +449,19 @@ class ClassTree extends Component {
 			return ide.reportError("Could not generate code");
 		const code = answer.parts.find((p) => p.code)?.code;
 		if (!code) return ide.reportError("Could not generate code");
-		const changeset = code.changeset();
-		await changeset.update();
+		//const changeset = code.changeset(ide.backend);
+		//await changeset.update();
 		//ide.browseChanges(changeset);
 		ide.updateAssistantChat();
 	};
 
 	isTestMethod = (method) => {
 		// This is meant to be removed when StMethod is used
-		return method && method.selector.startsWith("test");
+		return method && method.selector && method.selector.startsWith("test");
 	};
 
 	isTestClass = (species) => {
 		// This is meant to be removed when StClass is used
-		console.log(species);
 		return species && species.name.endsWith("Test");
 	};
 

--- a/src/components/parts/CodeBrowser.js
+++ b/src/components/parts/CodeBrowser.js
@@ -84,6 +84,7 @@ class CodeBrowser extends Component {
 				defaultValue: target,
 				required: true,
 			});
+			if (!newName) return;
 			await ide.backend.renameClass(target, newName);
 			this.props.class.name = newName;
 			if (this.props.onRenameClass) {

--- a/src/components/parts/CodeEditor.js
+++ b/src/components/parts/CodeEditor.js
@@ -300,16 +300,11 @@ class CodeEditor extends Component {
 	}
 
 	renameIdentifier = async (identifier) => {
-		var replacement;
-		try {
-			replacement = await ide.prompt({
-				title: "Replacement",
-				defaultValue: identifier,
-			});
-		} catch (error) {}
-		if (!replacement) {
-			return;
-		}
+		const replacement = await ide.prompt({
+			title: "Replacement",
+			defaultValue: identifier,
+		});
+		if (!replacement) return;
 		const changes = this.rangesContainingIdentifier(identifier).map(
 			(range) => {
 				return {
@@ -1048,7 +1043,7 @@ class CodeEditor extends Component {
 		if (!word || word.from === word.to || word.text.trim().length <= 0)
 			return null;
 		const classname = this.props.class ? this.props.class.name : null;
-		var options;
+		let options;
 		try {
 			options = await ide.backend.autocompletions(
 				classname,

--- a/src/components/parts/ColorEditor.js
+++ b/src/components/parts/ColorEditor.js
@@ -42,7 +42,9 @@ class ColorEditor extends Component {
 		const { name, editable } = this.props;
 		return (
 			<Box display="flex" flexDirection="row" alignItems="center">
-				<Typography mr={2}>{this.rgba()}</Typography>
+				<Typography mr={2} sx={{ minWidth: 100 }}>
+					{this.rgba()}
+				</Typography>
 				<TextField
 					sx={{ minWidth: 50 }}
 					size="small"

--- a/src/components/parts/ExpressionTable.js
+++ b/src/components/parts/ExpressionTable.js
@@ -39,14 +39,13 @@ class ExpressionTable extends Component {
 			const source = await ide.prompt({
 				title: "Expression",
 			});
-			if (source) {
-				const expression = {
-					id: this.newExpressionId(),
-					sourceCode: source,
-				};
-				await this.evaluateExpression(expression);
-				this.props.onExpressionAdd(expression);
-			}
+			if (!source) return;
+			const expression = {
+				id: this.newExpressionId(),
+				sourceCode: source,
+			};
+			await this.evaluateExpression(expression);
+			this.props.onExpressionAdd(expression);
 		} catch (error) {}
 	};
 

--- a/src/components/parts/MethodList.js
+++ b/src/components/parts/MethodList.js
@@ -223,7 +223,11 @@ class MethodList extends Component {
 	}
 
 	async fetchExtendedOptions() {
-		return await ide.backend.extensions("method");
+		let extensions = [];
+		try {
+			extensions = await ide.backend.extensions("method");
+		} catch (ignored) {}
+		return extensions;
 	}
 
 	async updateExtendedOptions() {
@@ -250,15 +254,14 @@ class MethodList extends Component {
 	};
 
 	renameMethod = async (method) => {
-		if (!method) {
-			return;
-		}
+		if (!method) return;
 		try {
 			const newSelector = await ide.prompt({
 				title: "Rename selector",
 				defaultValue: method.selector,
 				required: true,
 			});
+			if (!newSelector) return;
 			await ide.waitFor(() =>
 				ide.backend.renameSelector(
 					method.methodClass,
@@ -344,11 +347,9 @@ class MethodList extends Component {
 	classifyMethod = async (method, category) => {
 		var target = category;
 		if (!target) {
-			try {
-				target = await ide.prompt({
-					title: "New category",
-				});
-			} catch (error) {}
+			target = await ide.prompt({
+				title: "New category",
+			});
 		}
 		if (!target) return;
 		try {
@@ -367,15 +368,12 @@ class MethodList extends Component {
 	};
 
 	chooseCategoryForMethod = async (method) => {
-		var category;
-		try {
-			category = await ide.choose({
-				title: "Category",
-				message: "Select a category",
-				items: this.state.categories,
-				filter: true,
-			});
-		} catch (error) {}
+		const category = await ide.choose({
+			title: "Category",
+			message: "Select a category",
+			items: this.state.categories,
+			filter: true,
+		});
 		if (category) {
 			this.classifyMethod(method, category);
 		}
@@ -471,7 +469,7 @@ class MethodList extends Component {
 	};
 
 	isTestMethod = (method) => {
-		return method && method.selector.startsWith("test");
+		return method && method.selector && method.selector.startsWith("test");
 	};
 
 	canAddMethod = (method) => {

--- a/src/components/parts/PackageList.js
+++ b/src/components/parts/PackageList.js
@@ -54,7 +54,11 @@ class PackageList extends Component {
 	}
 
 	async fetchExtendedOptions() {
-		return await ide.backend.extensions("package");
+		let extensions = [];
+		try {
+			extensions = await ide.backend.extensions("package");
+		} catch (ignored) {}
+		return extensions;
 	}
 
 	async updateExtendedOptions() {
@@ -76,6 +80,7 @@ class PackageList extends Component {
 				title: "New package",
 				required: true,
 			});
+			if (!name) return;
 			await ide.backend.createPackage(name);
 			let pack = await ide.backend.packageNamed(name);
 			let packages = this.state.packages;
@@ -100,6 +105,7 @@ class PackageList extends Component {
 				defaultValue: pack.name,
 				required: true,
 			});
+			if (!newName) return;
 			await ide.backend.renamePackage(pack.name, newName);
 			pack.name = newName;
 			let packages = this.state.packages;

--- a/src/components/parts/PackageTree.js
+++ b/src/components/parts/PackageTree.js
@@ -72,7 +72,11 @@ class PackageTree extends Component {
 	}
 
 	async fetchExtendedOptions() {
-		return await ide.backend.extensions("package");
+		let extensions = [];
+		try {
+			extensions = await ide.backend.extensions("package");
+		} catch (ignored) {}
+		return extensions;
 	}
 
 	async updateExtendedOptions() {
@@ -135,6 +139,7 @@ class PackageTree extends Component {
 				title: "New package",
 				required: true,
 			});
+			if (!name) return;
 			await ide.backend.createPackage(name);
 			let pack = { name: name };
 			await this.updatePackage(pack);
@@ -158,6 +163,7 @@ class PackageTree extends Component {
 				defaultValue: pack.name,
 				required: true,
 			});
+			if (!newName) return;
 			await ide.backend.renamePackage(pack.name, newName);
 			pack.name = newName;
 			let packages = this.state.packages;
@@ -213,6 +219,7 @@ class PackageTree extends Component {
 				title: "New category",
 				required: true,
 			});
+			if (!name) return;
 			await ide.backend.addClassCategory(pack.name, name);
 			await this.updatePackage(pack);
 			let expanded = this.state.expandedNodes;
@@ -236,6 +243,7 @@ class PackageTree extends Component {
 				title: "Rename category",
 				defaultValue: category.name,
 			});
+			if (!name) return;
 			await ide.backend.renameClassCategory(
 				category.package,
 				category.name,

--- a/src/components/parts/VariableList.js
+++ b/src/components/parts/VariableList.js
@@ -53,7 +53,11 @@ class VariableList extends Component {
 	}
 
 	async fetchExtendedOptions() {
-		return await ide.backend.extensions("variable");
+		let extensions = [];
+		try {
+			extensions = await ide.backend.extensions("variable");
+		} catch (ignored) {}
+		return extensions;
 	}
 
 	async updateExtendedOptions() {
@@ -94,6 +98,7 @@ class VariableList extends Component {
 				title: "New instance variable",
 				required: true,
 			});
+			if (!name) return;
 			await ide.backend.addInstanceVariable(this.props.class.name, name);
 			let variables = await this.fetchVariables();
 			let variable = variables.find((v) => v.name === name);
@@ -116,6 +121,7 @@ class VariableList extends Component {
 				defaultValue: variable.name,
 				required: true,
 			});
+			if (!newName) return;
 			if (variable.type === "instance") {
 				await ide.backend.renameInstanceVariable(
 					this.props.class.name,

--- a/src/components/tools/Inspector.js
+++ b/src/components/tools/Inspector.js
@@ -74,16 +74,13 @@ class Inspector extends Tool {
 	};
 
 	updateViews = async (object) => {
+		let views = [];
 		try {
 			const id = this.props.root.id;
 			const path = this.objectURIPath(object);
-			object.views = await ide.backend.objectViews(
-				id,
-				path
-			);
-		} catch (error) {
-			ide.reportError(error);
-		}
+			views = await ide.backend.objectViews(id, path);
+		} catch (ignored) {}
+		object.views = views;
 	};
 
 	selfSlot(object) {


### PR DESCRIPTION
When a dialog is cancelled, the client code should handle an undefined result.

Also, some backend requests where not covered by try-catch statements