### PR TITLE
Try to retain selections when changing class in System Browser 

### DIFF
--- a/src/components/Backend.js
+++ b/src/components/Backend.js
@@ -252,7 +252,7 @@ class Backend {
 
 	async methods(classname, sorted = false) {
 		const methods = await this.get(
-			"/classes/" + classname + "/methods?marks=true",
+			"/classes/" + classname + "/methods",
 			"methods of class " + classname
 		);
 		if (sorted) {

--- a/src/components/parts/CategoryList.js
+++ b/src/components/parts/CategoryList.js
@@ -28,7 +28,7 @@ class CategoryList extends Component {
 
 	componentDidUpdate(prevProps) {
 		if (this.props.class !== prevProps.class) {
-			this.updateCategories();
+			this.updateCategories(this.state.selectedCategory);
 		}
 	}
 
@@ -38,8 +38,8 @@ class CategoryList extends Component {
 
 	async updateCategories(selectedCategory) {
 		this.setState({ loading: true });
-		let categories = await this.fetchCategories();
-		let selected = categories.defined.find((c) => c === selectedCategory);
+		const categories = await this.fetchCategories();
+		const selected = categories.defined.find((c) => c === selectedCategory);
 		this.setState({
 			loading: false,
 			categories: categories.defined,

--- a/src/components/parts/ClassTree.js
+++ b/src/components/parts/ClassTree.js
@@ -261,7 +261,7 @@ class ClassTree extends Component {
 		let names;
 		try {
 			names = ide.backend.searchClassNames(text);
-		} catch (error) {}
+		} catch (ignored) {}
 		return names;
 	};
 

--- a/src/components/parts/MethodList.js
+++ b/src/components/parts/MethodList.js
@@ -120,9 +120,7 @@ class MethodList extends Component {
 		let selected;
 		if (selectedMethod) {
 			selected = methods.find(
-				(m) =>
-					m.methodClass === selectedMethod.methodClass &&
-					m.selector === selectedMethod.selector
+				(m) => m.selector === selectedMethod.selector //&& m.methodClass === selectedMethod.methodClass
 			);
 		}
 		let categories = await this.fetchCategories(selected);

--- a/src/components/parts/VariableList.js
+++ b/src/components/parts/VariableList.js
@@ -25,17 +25,25 @@ class VariableList extends Component {
 
 	componentDidUpdate(prevProps) {
 		if (this.props.class !== prevProps.class) {
-			this.updateVariables();
+			this.updateVariables(this.state.selectedVariable);
 		}
 	}
 
-	async updateVariables() {
+	async updateVariables(selectedVariable) {
 		this.setState({ loading: true });
-		let variables = await this.fetchVariables();
+		const variables = await this.fetchVariables();
+		let selected;
+		if (selectedVariable) {
+			selected = variables.find(
+				(v) =>
+					v.name === selectedVariable.name &&
+					v.type === selectedVariable.type
+			);
+		}
 		this.setState({
 			loading: false,
 			variables: variables,
-			selectedVariable: null,
+			selectedVariable: selected,
 		});
 	}
 

--- a/src/components/tools/SystemBrowser.js
+++ b/src/components/tools/SystemBrowser.js
@@ -175,11 +175,40 @@ class SystemBrowser extends Tool {
 	classSelected = async (species) => {
 		this.updateLabel(species.name);
 		await this.updateClass(species);
+		const { selectedMethod, selectedCategory, selectedVariable } =
+			this.state;
+		let method;
+		if (selectedMethod) {
+			try {
+				method = await ide.backend.method(
+					species.name,
+					selectedMethod.selector
+				);
+			} catch (ignored) {}
+		}
+		let category;
+		if (selectedCategory) {
+			try {
+				const categories = await ide.backend.categories(species.name);
+				category = categories.find((c) => c === selectedCategory);
+			} catch (ignored) {}
+		}
+		let variable;
+		if (selectedVariable) {
+			try {
+				const variables = await ide.backend.variables(species.name);
+				variable = variables.find(
+					(v) =>
+						v.name === selectedVariable.name &&
+						v.type === selectedVariable.type
+				);
+			} catch (ignored) {}
+		}
 		this.setState({
 			selectedClass: species,
-			selectedCategory: null,
-			selectedVariable: null,
-			selectedMethod: null,
+			selectedCategory: category,
+			selectedVariable: variable,
+			selectedMethod: method,
 		});
 	};
 
@@ -283,7 +312,6 @@ class SystemBrowser extends Tool {
 				method.methodClass,
 				method.selector
 			);
-
 			if (retrieved) {
 				Object.assign(method, retrieved);
 			} else {


### PR DESCRIPTION
Whenever the user selects a class different from the currently selected, it is nice to (try to) keep variable, category and/or method selections (if the new selected class has a variable, a category and/or method with the correspoding name/selector)