### PR TITLE
Remove the options to close tabs in Inspector. 

### DIFF
--- a/src/components/controls/TabControl.js
+++ b/src/components/controls/TabControl.js
@@ -61,7 +61,13 @@ class TabControl extends Component {
 
 	render() {
 		const { addMenuOpen, selectMenuOpen } = this.state;
-		const { id, pages, selectedPage, showTabClose, showClose } = this.props;
+		const {
+			id,
+			pages,
+			selectedPage,
+			canCloseTabs = true,
+			showClose,
+		} = this.props;
 		const addOptions = this.props.addOptions || [];
 		const selectedIndex = pages.findIndex(
 			(p) => p && selectedPage && p.id === selectedPage.id
@@ -114,7 +120,7 @@ class TabControl extends Component {
 													this.closeOtherTabs
 												}
 												//onSplit={this.splitTab} //disabled for the moment
-												showClose={showTabClose}
+												showCloseOptions={canCloseTabs}
 											/>
 										}
 									/>
@@ -231,22 +237,24 @@ class TabControl extends Component {
 												</Box>
 												<Box>{page.label}</Box>
 											</Box>
-											<Box>
-												<IconButton
-													onClick={(event) => {
-														this.closeTab(
-															event,
-															index
-														);
-														this.setState({
-															selectMenuOpen: false,
-														});
-													}}
-													size="small"
-												>
-													<CloseIcon fontSize="small" />
-												</IconButton>
-											</Box>
+											{canCloseTabs && (
+												<Box>
+													<IconButton
+														onClick={(event) => {
+															this.closeTab(
+																event,
+																index
+															);
+															this.setState({
+																selectMenuOpen: false,
+															});
+														}}
+														size="small"
+													>
+														<CloseIcon fontSize="small" />
+													</IconButton>
+												</Box>
+											)}
 										</Box>
 									</MenuItem>
 								);

--- a/src/components/controls/TabLabel.js
+++ b/src/components/controls/TabLabel.js
@@ -30,24 +30,34 @@ class TabLabel extends Component {
 	};
 
 	menuOptions() {
-		return [
-			{
-				label: "Close",
-				action: this.closeTab,
-			},
-			{
-				label: "Close all",
-				action: this.closeAllTabs,
-			},
-			{
-				label: "Close others",
-				action: this.closeOtherTabs,
-			},
-			// {	//disabled for the moment
-			// 	label: "Split",
-			// 	action: this.splitTab,
-			// },
-		];
+		const options = [];
+		const showCloseOptions =
+			this.props.showCloseOptions === undefined
+				? true
+				: this.props.showCloseOptions;
+		if (showCloseOptions) {
+			options.push(
+				...[
+					{
+						label: "Close",
+						action: this.closeTab,
+					},
+					{
+						label: "Close all",
+						action: this.closeAllTabs,
+					},
+					{
+						label: "Close others",
+						action: this.closeOtherTabs,
+					},
+				]
+			);
+		}
+		// {	//disabled for the moment
+		// 	label: "Split",
+		// 	action: this.splitTab,
+		// },
+		return options;
 	}
 
 	splitTab = () => {
@@ -73,11 +83,10 @@ class TabLabel extends Component {
 	}
 
 	render() {
-		const { index, icon, onClose } = this.props;
-		let showClose =
-			this.props.showClose === undefined ? true : this.props.showClose;
+		const { index, icon, onClose, showCloseOptions = true } = this.props;
 		const { menuOpen, menuPosition } = this.state;
 		const text = this.visibleLabel();
+		const menuOptions = this.menuOptions();
 		return (
 			<Box
 				display="flex"
@@ -93,7 +102,7 @@ class TabLabel extends Component {
 					{text}
 				</Box>
 				<Box pt={1}>
-					{showClose && (
+					{showCloseOptions && (
 						<IconButton
 							onClick={(event) => {
 								onClose(event, index);
@@ -110,12 +119,14 @@ class TabLabel extends Component {
 						</IconButton>
 					)}
 				</Box>
-				<PopupMenu
-					options={this.menuOptions()}
-					open={menuOpen}
-					position={menuPosition}
-					onClose={this.closeMenu}
-				/>
+				{menuOptions && menuOptions.length > 0 && (
+					<PopupMenu
+						options={menuOptions}
+						open={menuOpen}
+						position={menuPosition}
+						onClose={this.closeMenu}
+					/>
+				)}
 			</Box>
 		);
 	}

--- a/src/components/parts/ObjectPresenter.js
+++ b/src/components/parts/ObjectPresenter.js
@@ -183,7 +183,7 @@ class ObjectPresenter extends Component {
 				selectedPage={selectedPage}
 				pages={pages}
 				onTabSelect={(p) => this.setState({ selectedId: p.id })}
-				showTabClose={false}
+				canCloseTabs={false}
 			/>
 		);
 	}


### PR DESCRIPTION
Even when these tabs already hid the close button, they still had the option in menus.