### PR TITLE
Enable code editor full-view

### DIFF
--- a/src/components/IDE.js
+++ b/src/components/IDE.js
@@ -324,6 +324,8 @@ class IDE extends Component {
 		shortcuts.addShortcut("browseSenders", "Alt+n");
 		shortcuts.addShortcut("browseImplementors", "Alt+m");
 		shortcuts.addShortcut("browseClassReferences", "Alt+r");
+		shortcuts.addShortcut("toggleEditorFullView", "Alt+z");
+		
 		// Code assistant...
 		const assistant = settings.addSection("codeAssistant");
 		assistant.addBoolean("enabled", false, "Use code assistant");

--- a/src/components/parts/CodeBrowser.js
+++ b/src/components/parts/CodeBrowser.js
@@ -349,6 +349,10 @@ class CodeBrowser extends Component {
 			this.props.onExtendedOptionPerform();
 	};
 
+	toggleFullView = () => {
+		if (this.props.onFullViewToggle) this.props.onFullViewToggle();
+	};
+
 	render() {
 		const { selectedMode, previewMarkdown } = this.state;
 		const author = this.currentAuthor();
@@ -435,6 +439,7 @@ class CodeBrowser extends Component {
 									this.extendedOptionPerformed
 								}
 								useMethodLexer={selectedMode === "source"}
+								onFullViewToggle={this.toggleFullView}
 							/>
 						)}
 						{selectedMode === "comment" && previewMarkdown && (

--- a/src/components/parts/CodeEditor.js
+++ b/src/components/parts/CodeEditor.js
@@ -431,6 +431,14 @@ class CodeEditor extends Component {
 					label: "Search string references",
 					action: this.browseStringReferences,
 				},
+				null,
+				{
+					label:
+						"Toggle full view (" +
+						shortcuts.get("toggleEditorFullView") +
+						")",
+					action: this.toggleFullView,
+				},
 			]
 		);
 		const extended = ide.extensionMenuOptions(
@@ -844,6 +852,10 @@ class CodeEditor extends Component {
 				key: "Tab",
 				run: acceptCompletion,
 			},
+			{
+				key: this.adaptShortcut(shortcuts.get("toggleEditorFullView")),
+				run: this.toggleFullView,
+			},
 		];
 	}
 
@@ -1135,6 +1147,10 @@ class CodeEditor extends Component {
 		lexer.tokenTable = newTags;
 		return StreamLanguage.define(lexer);
 	}
+
+	toggleFullView = () => {
+		if (this.props.onFullViewToggle) this.props.onFullViewToggle();
+	};
 
 	render() {
 		console.log("rendering code editor");

--- a/src/components/tools/Debugger.js
+++ b/src/components/tools/Debugger.js
@@ -20,6 +20,7 @@ class Debugger extends Tool {
 			stepping: false,
 			showBindings: true,
 			expressions: [],
+			editorFullView: false,
 		};
 		this.tempObjects = [];
 	}
@@ -280,12 +281,22 @@ class Debugger extends Tool {
 		});
 	};
 
+	toggleFullView = () => {
+		this.setState({ editorFullView: !this.state.editorFullView });
+	};
+
 	render() {
 		const id = this.props.id;
 		var title = this.props.title || "";
 		if (title.length > 100) title = title.slice(0, 50) + "...";
-		const { frames, selectedFrame, stepping, showBindings, expressions } =
-			this.state;
+		const {
+			frames,
+			selectedFrame,
+			stepping,
+			showBindings,
+			expressions,
+			editorFullView,
+		} = this.state;
 		const background = ide.colorSetting("debuggerColor");
 		return (
 			<Box
@@ -344,7 +355,10 @@ class Debugger extends Tool {
 				</Box>
 				<Box flexGrow={1}>
 					<CustomSplit mode="vertical">
-						<Box sx={{ minHeight: 50, height: "35%" }}>
+						<Box
+							hidden={editorFullView}
+							sx={{ minHeight: 50, height: "35%" }}
+						>
 							<CustomSplit>
 								<Box sx={{ width: "70%" }}>
 									<CustomPaper>
@@ -379,7 +393,7 @@ class Debugger extends Tool {
 								</Box>
 							</CustomSplit>
 						</Box>
-						<Box sx={{ height: "60%" }}>
+						<Box sx={{ height: editorFullView ? "100%" : "60%" }}>
 							<CodeBrowser
 								context={this.evaluationContext()}
 								class={
@@ -397,6 +411,7 @@ class Debugger extends Tool {
 								onClassDefine={this.classDefined}
 								onClassComment={this.classCommented}
 								onTooltipShow={this.tooltipForBinding}
+								onFullViewToggle={this.toggleFullView}
 							/>
 						</Box>
 					</CustomSplit>

--- a/src/components/tools/SystemBrowser.js
+++ b/src/components/tools/SystemBrowser.js
@@ -36,6 +36,7 @@ class SystemBrowser extends Tool {
 			selectedMethod: null,
 			preselectedClass: null,
 			preselectedPackage: null,
+			editorFullView: false,
 		};
 	}
 
@@ -375,6 +376,10 @@ class SystemBrowser extends Tool {
 		this.setState({ selectedMethod: method });
 	};
 
+	toggleFullView = () => {
+		this.setState({ editorFullView: !this.state.editorFullView });
+	};
+
 	render() {
 		const {
 			roots,
@@ -387,6 +392,7 @@ class SystemBrowser extends Tool {
 			selectedMethod,
 			preselectedClass,
 			preselectedPackage,
+			editorFullView,
 		} = this.state;
 		const targetClass = this.targetClass();
 		const showPackages = this.props.showPackages;
@@ -403,7 +409,10 @@ class SystemBrowser extends Tool {
 				}}
 			>
 				<CustomSplit mode="vertical">
-					<Box sx={{ minHeight: 50, height: "35%" }}>
+					<Box
+						hidden={editorFullView}
+						sx={{ minHeight: 50, height: "35%" }}
+					>
 						<Box
 							display="flex"
 							flexDirection="row"
@@ -579,7 +588,7 @@ class SystemBrowser extends Tool {
 							</CustomSplit>
 						</Box>
 					</Box>
-					<Box sx={{ height: "60%" }}>
+					<Box sx={{ height: editorFullView ? "100%" : "60%" }}>
 						<CodeBrowser
 							context={this.evaluationContext()}
 							category={selectedCategory}
@@ -592,6 +601,7 @@ class SystemBrowser extends Tool {
 							onExtendedOptionPerform={
 								this.codeExtendedOptionPerformed
 							}
+							onFullViewToggle={this.toggleFullView}
 							sx={{ height: "100%" }}
 						/>
 					</Box>


### PR DESCRIPTION
Enable code editor full-view in SystemBrowser, MethodBrowser and Debugger, both by context menu and via shorcut.