### PR TITLE
Ignore errors when evaluating code for tooltips

### DIFF
--- a/src/components/tools/Debugger.js
+++ b/src/components/tools/Debugger.js
@@ -232,7 +232,9 @@ class Debugger extends Tool {
 				name,
 				false,
 				true,
-				this.evaluationContext()
+				this.evaluationContext(),
+				null,
+				true
 			);
 		} catch (error) {
 			this.context.reportError(error);


### PR DESCRIPTION
Ignore errors when evaluating code for tooltips (e.g., bindings in de bugger)