### PR TITLE
Make Inspector to optionally preserve the underlying object

### DIFF
--- a/src/components/tools/Inspector.js
+++ b/src/components/tools/Inspector.js
@@ -23,8 +23,10 @@ class Inspector extends Tool {
 	}
 
 	async aboutToClose() {
+		const { root, preserveObject } = this.props;
+		if (!root || preserveObject) return;
 		try {
-			await ide.backend.unpinObject(this.props.root.id);
+			await ide.backend.unpinObject(root.id);
 		} catch (error) {
 			ide.reportError(error);
 		}


### PR DESCRIPTION
Make Inspector to optionally preserve the underlying object (i.e., not unpining it when closing)